### PR TITLE
Update deprecated call

### DIFF
--- a/celery.php
+++ b/celery.php
@@ -192,7 +192,7 @@ class AsyncResult
 		$q->setName($this->task_id);
 		$q->setFlags(AMQP_AUTODELETE);
 #		$q->setArgument('x-expires', 86400000);
-		$q->declare();
+		$q->declareQueue();
 		try
 		{
 			$q->bind('celeryresults', $this->task_id);


### PR DESCRIPTION
`AMQPQueue::declare()` is now deprecated (see: https://github.com/pdezwart/php-amqp/pull/58 ).

I just updated to the new method.
declareQueue is defined since the 1.0.8 version.
