### PR TITLE
PostTask using exchange name as binding

### DIFF
--- a/celery.php
+++ b/celery.php
@@ -132,7 +132,7 @@ class Celery
 			'immediate' => false,
 			);
                 
-		$success = $xchg->publish($task, $this->connection_details['exchange'], 0, $params);
+		$success = $xchg->publish($task, $this->connection_details['binding'], 0, $params);
 		$this->connection->disconnect();
 
 		return new AsyncResult($id, $this->connection_details, $task_array['task'], $args);


### PR DESCRIPTION
Seems to be a typo to just use the exchange name rather than the routing key. Test is successful because the exchange and binding names are the same in that case.
