### PR TITLE
fixing wrong prototype for GetConcrete function

### DIFF
--- a/amqp.php
+++ b/amqp.php
@@ -25,7 +25,7 @@ abstract class AbstractAMQPConnector
 	 * @param string $name Name of desired concrete object: 'pecl', 'php-amqplib' or false: autodetect
 	 * @return AbstractAMQPConnector concrete object implementing AbstractAMQPConnector interface
 	 */
-	function GetConcrete($name = false)
+	static function GetConcrete($name = false)
 	{
 		if($name === false)
 		{


### PR DESCRIPTION
Fixing a bug, the `static` statement is currently missing from the `GetConcrete` function's prototype.
Executing `new Celery();` actually result in a crash.
