### PR TITLE
Fixes incompatibility with PECL AMQP v1.4.0

### DIFF
--- a/amqppeclconnector.php
+++ b/amqppeclconnector.php
@@ -68,7 +68,7 @@ class PECLAMQPConnector extends AbstractAMQPConnector
 		$q = new AMQPQueue($ch);
 		$q->setName($task_id);
 		$q->setFlags(AMQP_AUTODELETE | AMQP_DURABLE);
-		$q->declare();
+		$q->declareQueue();
 		try
 		{
 			$q->bind('celeryresults', $task_id);


### PR DESCRIPTION
The method AMQPQueue::declare() was deprecated in favor of AMQPQueue::declareQueue() since PECL AMQP version 1.2.0.  The older method AMQPQueue::declare() does not work with PECL AMQP version 1.4.0
