### PR TITLE
Fix RedisConnector for PHP 5.3

### DIFF
--- a/redisconnector.php
+++ b/redisconnector.php
@@ -66,7 +66,7 @@ class RedisConnector extends AbstractAMQPConnector {
 
     public function getMessage($task) {
 
-        $result = [];
+        $result = Array();
         $result['body'] = base64_encode($task);
         $result['headers'] = $this->getHeaders();
         $result['content-type'] = $this->content_type;
@@ -91,17 +91,17 @@ class RedisConnector extends AbstractAMQPConnector {
         $connection = $this->Connect($connection);
         $body = json_decode($task, true);
         $message = $this->getMessage($task);
-        $message['properties'] = [
+        $message['properties'] = Array(
             'body_encoding' => 'base64',
             'reply_to' => $body['id'],
-            'delivery_info' => [
+            'delivery_info' => Array(
                 'priority' => 0,
                 'routing_key' => $details['binding'],
                 'exchange' => $details['exchange'],
-            ],
+            ),
             'delivery_mode' => $this->getDeliveryMode(),
             'delivery_tag'  => $body['id']
-        ];
+        );
         $connection->lPush($details['exchange'], $this->toStr($message));
 		return TRUE;
     }
@@ -132,10 +132,10 @@ class RedisConnector extends AbstractAMQPConnector {
         $result = $connection->get($this->getResultKey($task_id));
         if ($result) {
             $redis_result = $this->toDict($result, true);
-            $result = [
+            $result = Array(
                 'complete_result' => $redis_result['status'],
                 'body' => json_encode($redis_result)
-            ];
+            );
             $this->finalizeResult($connection, $task_id);
             return $result;
         }
@@ -145,12 +145,12 @@ class RedisConnector extends AbstractAMQPConnector {
     }
 
     function GetConnectionObject($details) {
-        $connect = new Predis\Client([
+        $connect = new Predis\Client(Array(
             'scheme' => 'tcp',
             'host'   => $details['host'],
             'port'   => $details['port'],
             'database' => $details['vhost']
-        ]);
+        ));
         return $connect;
     }
 }


### PR DESCRIPTION
PHP prior version 5.4 does not support short array syntax ($a=[];) 
The pathch replaces it with $a=Array();
