### PR TITLE
Require autoload.php in tests only

### DIFF
--- a/amqp.php
+++ b/amqp.php
@@ -1,8 +1,5 @@
 <?php
 
-/* Include Composer installed packages if available */
-@include_once('vendor/autoload.php');
-
 /* Include namespaced code only if PhpAmqpLib available */
 if(class_exists('PhpAmqpLib\Connection\AMQPConnection'))
 {

--- a/amqplibconnectorssl.php
+++ b/amqplibconnectorssl.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once('amqp.php');
-require_once('vendor/autoload.php');
 
 use PhpAmqpLib\Connection\AMQPSSLConnection;
 use PhpAmqpLib\Message\AMQPMessage;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "massivescale/celery-php",
+    "name": "jjbubudi/celery-php",
     "type": "library",
     "description": "PHP client for Celery task queue",
     "keywords": ["celery", "amqp", "task", "cron", "queue", "python"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jjbubudi/celery-php",
+    "name": "massivescale/celery-php",
     "type": "library",
     "description": "PHP client for Celery task queue",
     "keywords": ["celery", "amqp", "task", "cron", "queue", "python"],

--- a/unittest/unittest.php
+++ b/unittest/unittest.php
@@ -46,6 +46,7 @@ composer global require 'phpunit/phpunit'
  phpunit CeleryAMQPLibTest unittest/CeleryAMQPLibTest.php
  */
 
+require_once('vendor/autoload.php');
 require_once('celery.php');
 
 


### PR DESCRIPTION
Fix https://github.com/gjedeer/celery-php/issues/38

Hi, I found that 2 paths doesn't work when the package is installed through Composer