### PR TITLE
Add export-ignore .gitattributes to reduce the size of the release th…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.gitattributes export-ignore
+/DEVELOPMENT.md
+/README.md export-ignore
+/docgen export-ignore
+/install_amqp.sh export-ignore
+/test.php export-ignore
+/testscenario export-ignore
+/unittest export-ignore


### PR DESCRIPTION
…rough composer.

This can help reduce the amount of needlessly transferred code when
installing dependencies.