### PR TITLE
Suggest backend libraries instead of requiring them.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "description": "PHP client for Celery task queue",
     "keywords": ["celery", "amqp", "task", "cron", "queue", "redis", "python"],
     "homepage": "https://github.com/gjedeer/celery-php/",
-	"support": {
-		"issues": "https://github.com/gjedeer/celery-php/issues",
-		"docs": "https://github.com/gjedeer/celery-php/"
-	},
+    "support": {
+	"issues": "https://github.com/gjedeer/celery-php/issues",
+	"docs": "https://github.com/gjedeer/celery-php/"
+    },
     "license": "BSD-2-Clause",
     "authors": [
         {
@@ -17,9 +17,9 @@
             "role": "Developer"
         }
     ],
-    "require": {
-		"videlalvaro/php-amqplib": ">=2.4.0",
-        "predis/predis": ">=0.8.5"
+    "suggest": {
+	"videlalvaro/php-amqplib": "Adds support for the php-amqplib, AMQP library for PHP, backend",
+        "predis/predis": "Adds support for the predis, PHP client library for Redis, backend"
     },
     "autoload": {
         "classmap": ["celery.php"]


### PR DESCRIPTION
This allows users of the PECL backend to avoid installing unnecassary
third party packages. These packages consume time and bandwidth to
download and deploy across production servers.

The suggestion still makes it clear to other users that they can
continue using the other backends by installing the suggested
packages.