### PR TITLE
A wild CeleryConfig class appears! (and it lets us configure things)

### DIFF
--- a/celery.php
+++ b/celery.php
@@ -62,6 +62,45 @@ class CeleryPublishException extends CeleryException {};
 require('amqp.php');
 
 /**
+ * A container for arbitrary configuration for instances of
+ * the Celery class. Meant to reduce the 'parameter bloat'
+ * of the Celery::__construct() method.
+ */
+class CeleryConfig {
+
+	/**
+	 * @var array
+	 *
+	 * Configuration values itself. Any used configuration keys
+	 * should have a default value listed and defined here,
+	 * so it is apparent what parameters for the Celery instance
+	 * can be modified.
+	 */
+	protected $config = array (
+		'keep_messages_in_queue' => false,
+	);
+
+	public function __construct(array $config = array()) {
+		$this->config = $config;
+	}
+
+	public function __get($name) {
+
+		if (!array_key_exists($name, $this->config)) {
+			throw new \LogicException("Config parameter '$name' not set");
+		}
+
+		return $this->config[$name];
+
+	}
+
+	public function __set($name, $value) {
+		throw new \LogicException("Cannot modify already created " . __CLASS__ . " object");
+	}
+
+}
+
+/**
  * Simple client for a Celery server
  *
  * for when queue and results are in the same broker
@@ -82,10 +121,24 @@ class Celery extends CeleryAbstract
 	* @param bool persistent_messages False = transient queue, True = persistent queue. Check "Using Transient Queues" in Celery docs (set to false when in doubt)
 	* @param int result_expire Expire time for result queue, milliseconds (for AMQP exchanges only)
 	* @param array ssl_options Used only for 'php-amqplib-ssl' connections, an associative array with values as defined here: http://php.net/manual/en/context.ssl.php
+	* @param CeleryObject Celery configuration object providint additional finess through modifying behaviour of Celery-PHP
 	*/
 
-	function __construct($host, $login, $password, $vhost, $exchange='celery', $binding='celery', $port=5672, $connector = false, $persistent_messages=false, $result_expire=0, $ssl_options = array() )
-	{
+	function __construct(
+		$host,
+		$login,
+		$password,
+		$vhost,
+		$exchange = 'celery',
+		$binding = 'celery',
+		$port = 5672,
+		$connector = false,
+		$persistent_messages = false,
+		$result_expire = 0,
+		$ssl_options = array(),
+		CeleryConfig $config_object = null
+	) {
+
 		$broker_connection = array(
 			'host' => $host,
 			'login' => $login,
@@ -98,10 +151,14 @@ class Celery extends CeleryAbstract
 			'result_expire' => $result_expire,
 			'ssl_options' => $ssl_options
 		);
+
+		$this->config = $config_object ?: new ConfigObject;
+
 		$backend_connection = $broker_connection;
 
 		$items = $this->BuildConnection($broker_connection);
 		$items = $this->BuildConnection($backend_connection, true);
+
 	}
 }
 
@@ -144,6 +201,8 @@ abstract class CeleryAbstract
 	private $backend_amqp = null;
 
 	private $isConnected = false;
+
+	protected $config = null;
 
 	private function SetDefaultValues($details) {
 		$defaultValues = array("host" => "", "login" => "", "password" => "", "vhost" => "", "exchange" => "celery", "binding" => "celery", "port" => 5672, "connector" => false, "persistent_messages" => false, "result_expire" => 0, "ssl_options" => array());
@@ -265,7 +324,7 @@ abstract class CeleryAbstract
 
         if($async_result) 
         {
-			return new AsyncResult($id, $this->backend_connection_details, $task_array['task'], $args);
+			return new AsyncResult($id, $this->backend_connection_details, $task_array['task'], $args, !$this->config->keep_messages_in_queue);
         } 
         else 
         {
@@ -314,6 +373,7 @@ class AsyncResult
 	private $complete_result; // Backend-dependent message instance (AMQPEnvelope or PhpAmqpLib\Message\AMQPMessage)
 	private $body; // decoded array with message body (whatever Celery task returned)
 	private $amqp = null; // AbstractAMQPConnector implementation
+	private $remove_from_queue = true;
 
 	/**
 	 * Don't instantiate AsyncResult yourself, used internally only
@@ -321,8 +381,9 @@ class AsyncResult
 	 * @param array $connection_details used to initialize AMQPConnection, keys are the same as args to Celery::__construct
 	 * @param string task_name
 	 * @param array task_args
+	 * @param bool Remove the result message from queue after fetching it?
 	 */
-	function __construct($id, $connection_details, $task_name=NULL, $task_args=NULL)
+	function __construct($id, $connection_details, $task_name=NULL, $task_args=NULL, $remove_from_queue = true)
 	{
 		$this->task_id = $id;
 		$this->connection = Celery::InitializeAMQPConnection($connection_details);
@@ -330,6 +391,7 @@ class AsyncResult
 		$this->task_name = $task_name;
 		$this->task_args = $task_args;
 		$this->amqp = AbstractAMQPConnector::GetConcrete($connection_details['connector']);
+		$this->remove_from_queue = $remove_from_queue;
 	}
 
 	function __wakeup()
@@ -351,7 +413,7 @@ class AsyncResult
 			return $this->complete_result;
 		}
 
-		$message = $this->amqp->GetMessageBody($this->connection, $this->task_id,$this->connection_details['result_expire'], true);
+		$message = $this->amqp->GetMessageBody($this->connection, $this->task_id, $this->connection_details['result_expire'], $this->remove_from_queue);
 		
 		if($message !== false)
 		{

--- a/celery.php
+++ b/celery.php
@@ -71,8 +71,8 @@ class CeleryConfig {
 	/**
 	 * @var array
 	 *
-	 * Configuration values itself. Any used configuration keys
-	 * should have a default value listed and defined here,
+	 * Configuration values. All possible configuration keys
+	 * should be listed here and have a default value defined,
 	 * so it is apparent what parameters for the Celery instance
 	 * can be modified.
 	 */
@@ -152,7 +152,7 @@ class Celery extends CeleryAbstract
 			'ssl_options' => $ssl_options
 		);
 
-		$this->config = $config_object ?: new ConfigObject;
+		$this->config = $config_object ?: new CeleryConfig;
 
 		$backend_connection = $broker_connection;
 

--- a/celery.php
+++ b/celery.php
@@ -628,10 +628,8 @@ class AsyncResult
 	 * Send revoke signal to all workers
 	 * Does nothing in PHP client
 	 */
-	function revoke($terminate = false)
+	function revoke()
 	{
-		// TODO
-		// return $this->amqp->RevokeTask($this->connection, $this->connection_details, $this->task_id);
 	}
 
 	/**

--- a/celery.php
+++ b/celery.php
@@ -414,13 +414,16 @@ class AsyncResult
 		}
 
 		$message = $this->amqp->GetMessageBody($this->connection, $this->task_id, $this->connection_details['result_expire'], $this->remove_from_queue);
-		
+
 		if($message !== false)
 		{
 			$this->complete_result = $message['complete_result'];
 			$this->body = json_decode(
 				$message['body']
 			);
+
+			return true;
+
 		}
 
 		return false;
@@ -625,8 +628,10 @@ class AsyncResult
 	 * Send revoke signal to all workers
 	 * Does nothing in PHP client
 	 */
-	function revoke()
+	function revoke($terminate = false)
 	{
+		// TODO
+		// return $this->amqp->RevokeTask($this->connection, $this->connection_details, $this->task_id);
 	}
 
 	/**

--- a/redisconnector.php
+++ b/redisconnector.php
@@ -72,7 +72,7 @@ Predis\Autoloader::register();
 	/**
 	* Prepare the message sent to Celery
 	*/
-	protected function GetMessage($task) 
+	protected function GetMessage($task)
 	{
 	   $result = Array();
 	   $result['body'] = base64_encode($task);
@@ -234,4 +234,12 @@ Predis\Autoloader::register();
 	   ));
 	   return $connect;
 	}
+
+	function RevokeTask($connection, $details, $task_id, $terminate = false) {
+
+		// TODO
+		// $connection->lPush($details['exchange'], $this->ToStr($message));
+
+	}
+
  }

--- a/redisconnector.php
+++ b/redisconnector.php
@@ -235,11 +235,4 @@ Predis\Autoloader::register();
 	   return $connect;
 	}
 
-	function RevokeTask($connection, $details, $task_id, $terminate = false) {
-
-		// TODO
-		// $connection->lPush($details['exchange'], $this->ToStr($message));
-
-	}
-
- }
+}


### PR DESCRIPTION
**_This solves the issue https://github.com/gjedeer/celery-php/issues/41.**_

**There is the new `CeleryConfig` class of which instance can be used to modify _celery-php_'s behaviour.**

First and only and for me most important thing at the moment is the new ability to control whether the messages obtained from the queue should stay in the queue after obtaining them.

I tried _(and I think I succeded)_ to not break any old behaviour with this - by my opinion - pretty substantial addition to the _celery-php_'s configurability.

The `CeleryConfig` instance **is optional** and placed at the end of the `Celery` class's constructor. I think most of the constructor's arguments could be placed inside the  `CeleryConfig` object, but for now I wanted **not to create any backwards incompatibility** since this definitely is not a new major version that could or should dare to do such thing.

_Tests are not provided, since I somehow wasn't able to run even the original ones at all. So please feel free to provide them._
