### PR TITLE
BUG: fix exchange routing

### DIFF
--- a/amqplibconnector.php
+++ b/amqplibconnector.php
@@ -106,7 +106,8 @@ class AMQPLibConnector extends AbstractAMQPConnector
 
 		$ch->queue_bind(
 			$details['binding'], 	/* queue name - "celery" */
-			$details['exchange'] 	/* exchange name - "celery" */
+			$details['exchange']. 	/* exchange name - "celery" */
+			$details['routing_key']
 		);
 
 		$msg = new AMQPMessage(


### PR DESCRIPTION
Creating tasks with custom routing key, when RabbitMq is empty should pass this parameter to bind properly newly created queue. But currently is not, so starting php apllication (before backend with celery) declares new exchange and queue with improper binding. In effect of that all new sent task are lost.

Example:
```
$celery = new Celery(...);

$taskName = 'someTaskName';
$taskData = ['lorem' => 'ipsum'];
$asyncResult = false;
$routingKey = 'someRoutingKey';

$celery->PostTask($taskName, $taskData, $asyncResult, $routingKey);
```