### PR TITLE
Celery v2 protocol metadata support

### DIFF
--- a/celery.php
+++ b/celery.php
@@ -270,7 +270,7 @@ abstract class CeleryAbstract
 			$task_metadata
 		);
 
-		$params = Array(
+		$properties = Array(
 			'content_type' => 'application/json',
 			'content_encoding' => 'UTF-8',
 			'immediate' => false,
@@ -294,7 +294,7 @@ abstract class CeleryAbstract
 
 		if($this->broker_connection_details['persistent_messages'])
 		{
-			$params['delivery_mode'] = 2;
+			$properties['delivery_mode'] = 2;
 		}
 
 		$this->broker_connection_details['routing_key'] = $routing_key;
@@ -303,7 +303,7 @@ abstract class CeleryAbstract
 			$this->broker_connection,
 			$this->broker_connection_details,
 			$task,
-			$params,
+			$properties,
 			$headers_array
 		);
 

--- a/celery.php
+++ b/celery.php
@@ -203,13 +203,13 @@ abstract class CeleryAbstract
    * @param array $args Array of arguments (kwargs call when $args is associative)
    * @param bool $async_result Set to false if you don't need the AsyncResult object returned
    * @param string $routing_key Set to routing key name if you're using something other than "celery"
-   * @param array $task_args Additional settings for Celery - normally not needed
+   * @param array $task_metadata Additional settings for Celery - normally not needed
    *
    * @return AsyncResult|bool
    * @throws CeleryException
    * @throws CeleryPublishException
    */
-	function PostTask($task, $args, $async_result=true,$routing_key="celery", $task_args=array())
+	function PostTask($task, $args, $async_result=true, $routing_key="celery", $task_metadata=array())
 	{
 		if(!is_array($args))
 		{
@@ -246,11 +246,11 @@ abstract class CeleryAbstract
 		$args_repr = substr($args_repr, 0, ARGSREPR_MAXSIZE);
 		$kwargs_repr = substr($kwargs_repr, 0, ARGSREPR_MAXSIZE);
 
-		 /*
-		 *	$task_args may contain additional arguments such as eta which are useful in task execution
-		 *	The usecase of this field is as follows:
-		 *	$task_args = array( 'eta' => "2014-12-02T16:00:00" );
-		  */
+    /**
+		 *	 $task_metadata may contain additional arguments such as 'eta' which are useful in task execution
+		 *	 The usecase of this field is as follows:
+		 *	 $task_metadata = array( 'eta' => "2014-12-02T16:00:00" );
+	   */
 		$headers_array = array_merge(
 		  Array(
         'lang' => "php",
@@ -267,7 +267,7 @@ abstract class CeleryAbstract
         'kwargsrepr' => $kwargs_repr,
         'origin' => $this->origin,
       ),
-      $task_args
+      $task_metadata
     );
 
 		$params = Array(

--- a/celery.php
+++ b/celery.php
@@ -73,8 +73,8 @@ define('KWARGSREPR_MAXSIZE', 1024);
  */
 class Celery extends CeleryAbstract 
 {
-   /**
-    * @param string host
+	/**
+	* @param string host
 	* @param string login
 	* @param string password
 	* @param string vhost AMQP vhost, may be left empty or NULL for non-AMQP backends like Redis
@@ -114,7 +114,7 @@ class Celery extends CeleryAbstract
  */
 class CeleryAdvanced extends CeleryAbstract 
 {
-    /**
+	/**
 	 * @param array broker_connection - array for connecting to task queue, see Celery class above for supported keys
 	 * @param array backend_connection - array for connecting to result backend, see Celery class above for supported keys
 	 */
@@ -196,19 +196,19 @@ abstract class CeleryAbstract
 		return $amqp->GetConnectionObject($details);
 	}
 
-  /**
-   * Post a task to Celery
-   *
-   * @param string $task Name of the task, prefixed with module name (like tasks.add for function add() in task.py)
-   * @param array $args Array of arguments (kwargs call when $args is associative)
-   * @param bool $async_result Set to false if you don't need the AsyncResult object returned
-   * @param string $routing_key Set to routing key name if you're using something other than "celery"
-   * @param array $task_metadata Additional settings for Celery - normally not needed
-   *
-   * @return AsyncResult|bool
-   * @throws CeleryException
-   * @throws CeleryPublishException
-   */
+	/**
+	 * Post a task to Celery
+	 *
+	 * @param string $task Name of the task, prefixed with module name (like tasks.add for function add() in task.py)
+	 * @param array $args Array of arguments (kwargs call when $args is associative)
+	 * @param bool $async_result Set to false if you don't need the AsyncResult object returned
+	 * @param string $routing_key Set to routing key name if you're using something other than "celery"
+	 * @param array $task_metadata Additional settings for Celery - normally not needed
+	 *
+	 * @return AsyncResult|bool
+	 * @throws CeleryException
+	 * @throws CeleryPublishException
+	 */
 	function PostTask($task, $args, $async_result=true, $routing_key="celery", $task_metadata=array())
 	{
 		if(!is_array($args))
@@ -246,37 +246,37 @@ abstract class CeleryAbstract
 		$args_repr = substr($args_repr, 0, ARGSREPR_MAXSIZE);
 		$kwargs_repr = substr($kwargs_repr, 0, ARGSREPR_MAXSIZE);
 
-    /**
+		/**
 		 *	 $task_metadata may contain additional arguments such as 'eta' which are useful in task execution
 		 *	 The usecase of this field is as follows:
 		 *	 $task_metadata = array( 'eta' => "2014-12-02T16:00:00" );
-	   */
+		 */
 		$headers_array = array_merge(
-		  Array(
-        'lang' => "php",
-        'task' => $task,
-        'id' => $id,
-        'eta' => NULL,
-        'expires' => NULL,
-        'group' => NULL,
-        'retries' => 0,
-        'timelimit' => array(NULL, NULL),
-        'root_id' => $id,
-        'parent_id' => NULL,
-        'argsrepr' => $args_repr,
-        'kwargsrepr' => $kwargs_repr,
-        'origin' => $this->origin,
-      ),
-      $task_metadata
-    );
+			Array(
+				'lang' => "php",
+				'task' => $task,
+				'id' => $id,
+				'eta' => NULL,
+				'expires' => NULL,
+				'group' => NULL,
+				'retries' => 0,
+				'timelimit' => array(NULL, NULL),
+				'root_id' => $id,
+				'parent_id' => NULL,
+				'argsrepr' => $args_repr,
+				'kwargsrepr' => $kwargs_repr,
+				'origin' => $this->origin,
+			),
+			$task_metadata
+		);
 
 		$params = Array(
-      'content_type' => 'application/json',
-      'content_encoding' => 'UTF-8',
-      'immediate' => false,
-      'reply_to' => $id,
-      'corellation_id' => $id,
-    );
+			'content_type' => 'application/json',
+			'content_encoding' => 'UTF-8',
+			'immediate' => false,
+			'reply_to' => $id,
+			'corellation_id' => $id,
+		);
 
 		/* Prepare the body */
 		$task_array = Array(
@@ -309,7 +309,7 @@ abstract class CeleryAbstract
 
 		if(!$success)
 		{
-		   throw new CeleryPublishException();
+			 throw new CeleryPublishException();
 		}
 
 		if($async_result) 

--- a/celery.php
+++ b/celery.php
@@ -245,38 +245,38 @@ abstract class CeleryAbstract
 		}
 		$args_repr = substr($args_repr, 0, ARGSREPR_MAXSIZE);
 		$kwargs_repr = substr($kwargs_repr, 0, ARGSREPR_MAXSIZE);
-                
-		 /* 
-		 *	$task_args may contain additional arguments such as eta which are useful in task execution 
+
+		 /*
+		 *	$task_args may contain additional arguments such as eta which are useful in task execution
 		 *	The usecase of this field is as follows:
 		 *	$task_args = array( 'eta' => "2014-12-02T16:00:00" );
-		  */ 
-		$headers_array = Array(
-			'lang' => "php",
-			'task' => $task,
-			'id' => $id,
-			'eta' => NULL,
-			'expires' => NULL,
-			'group' => NULL,
-			'retries' => 0,
-			'timelimit' => array(NULL, NULL),
-			'root_id' => $id,
-			'parent_id' => NULL,
-			'argsrepr' => $args_repr,
-			'kwargsrepr' => $kwargs_repr,
-			'origin' => $this->origin,
-		);
+		  */
+		$headers_array = array_merge(
+		  Array(
+        'lang' => "php",
+        'task' => $task,
+        'id' => $id,
+        'eta' => NULL,
+        'expires' => NULL,
+        'group' => NULL,
+        'retries' => 0,
+        'timelimit' => array(NULL, NULL),
+        'root_id' => $id,
+        'parent_id' => NULL,
+        'argsrepr' => $args_repr,
+        'kwargsrepr' => $kwargs_repr,
+        'origin' => $this->origin,
+      ),
+      $task_args
+    );
 
-		$params = array_merge(
-			Array(
-				'content_type' => 'application/json',
-				'content_encoding' => 'UTF-8',
-				'immediate' => false,
-				'reply_to' => $id,
-				'corellation_id' => $id,
-			),
-			$task_args
-		);
+		$params = Array(
+      'content_type' => 'application/json',
+      'content_encoding' => 'UTF-8',
+      'immediate' => false,
+      'reply_to' => $id,
+      'corellation_id' => $id,
+    );
 
 		/* Prepare the body */
 		$task_array = Array(

--- a/celery.php
+++ b/celery.php
@@ -196,15 +196,19 @@ abstract class CeleryAbstract
 		return $amqp->GetConnectionObject($details);
 	}
 
-	/**
-	 * Post a task to Celery
-	 * @param string $task Name of the task, prefixed with module name (like tasks.add for function add() in task.py)
-	 * @param array $args Array of arguments (kwargs call when $args is associative)
-	 * @param bool $async_result Set to false if you don't need the AsyncResult object returned
-	 * @param string $routing_key Set to routing key name if you're using something other than "celery"
-	 * @param array $task_args Additional settings for Celery - normally not needed
-	 * @return AsyncResult
-	 */
+  /**
+   * Post a task to Celery
+   *
+   * @param string $task Name of the task, prefixed with module name (like tasks.add for function add() in task.py)
+   * @param array $args Array of arguments (kwargs call when $args is associative)
+   * @param bool $async_result Set to false if you don't need the AsyncResult object returned
+   * @param string $routing_key Set to routing key name if you're using something other than "celery"
+   * @param array $task_args Additional settings for Celery - normally not needed
+   *
+   * @return AsyncResult|bool
+   * @throws CeleryException
+   * @throws CeleryPublishException
+   */
 	function PostTask($task, $args, $async_result=true,$routing_key="celery", $task_args=array())
 	{
 		if(!is_array($args))


### PR DESCRIPTION
This patch moves the task metadata from the message body to the message headers, due to the change between [Celery's v1 and v2 protocol](http://docs.celeryproject.org/en/latest/internals/protocol.html). This should fix #81, but doesn't provide the testing asked for by #80.