### PR TITLE
AsyncResult can be configured to keep messages in queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ php:
   - 7.1
 
 before_install:
+  # Get latest librabbitmq library
+  # php-amqp from PECL needs librabbitmq >= 0.5.2
+  # See: https://github.com/pdezwart/php-amqp#requirements
+  - sudo add-apt-repository -y ppa:ondrej/php && sudo apt-get update
+  - sudo apt install librabbitmq4 librabbitmq-dev
   - composer --no-interaction validate --strict
   # Install PECL amqp package
   - yes '' | pecl install amqp
@@ -20,7 +25,7 @@ before_install:
   - sudo rabbitmqctl add_vhost celerypecl
   - sudo rabbitmqctl set_permissions -p celerypecl gdr '.*' '.*' '.*'
   # Redis
-  - sudo start redis-server
+  - sudo service redis-server start
   # Celery
   - sudo apt-get install -y python-virtualenv
   - virtualenv venv

--- a/src/Celery.php
+++ b/src/Celery.php
@@ -64,9 +64,22 @@ class Celery extends CeleryAbstract
      * @param bool persistent_messages False = transient queue, True = persistent queue. Check "Using Transient Queues" in Celery docs (set to false when in doubt)
      * @param int result_expire Expire time for result queue, milliseconds (for AMQP exchanges only)
      * @param array ssl_options Used only for 'php-amqplib-ssl' connections, an associative array with values as defined here: http://php.net/manual/en/context.ssl.php
+     * @param CeleryObject Celery configuration object containing additional optional config.
      */
 
-    public function __construct($host, $login, $password, $vhost, $exchange='celery', $binding='celery', $port=5672, $connector=false, $persistent_messages=false, $result_expire=0, $ssl_options=[])
+    public function __construct(
+        $host,
+		$login,
+		$password,
+		$vhost,
+		$exchange = 'celery',
+		$binding = 'celery',
+		$port = 5672,
+		$connector = false,
+		$persistent_messages = false,
+		$result_expire = 0,
+		$ssl_options = array(),
+		Config $config_object = null)
     {
         $broker_connection = [
             'host' => $host,
@@ -80,6 +93,9 @@ class Celery extends CeleryAbstract
             'result_expire' => $result_expire,
             'ssl_options' => $ssl_options
         ];
+
+        $this->config = $config_object ?: new CeleryConfig;
+
         $backend_connection = $broker_connection;
 
         $items = $this->BuildConnection($broker_connection);

--- a/src/Celery.php
+++ b/src/Celery.php
@@ -69,17 +69,17 @@ class Celery extends CeleryAbstract
 
     public function __construct(
         $host,
-		$login,
-		$password,
-		$vhost,
-		$exchange = 'celery',
-		$binding = 'celery',
-		$port = 5672,
-		$connector = false,
-		$persistent_messages = false,
-		$result_expire = 0,
-		$ssl_options = array(),
-		Config $config_object = null)
+        $login,
+        $password,
+        $vhost,
+        $exchange = 'celery',
+        $binding = 'celery',
+        $port = 5672,
+        $connector = false,
+        $persistent_messages = false,
+        $result_expire = 0,
+        $ssl_options = array(),
+        Config $config_object = null)
     {
         $broker_connection = [
             'host' => $host,

--- a/src/Celery.php
+++ b/src/Celery.php
@@ -94,7 +94,7 @@ class Celery extends CeleryAbstract
             'ssl_options' => $ssl_options
         ];
 
-        $this->config = $config_object ?: new CeleryConfig;
+        $this->config = $config_object ?: new Config;
 
         $backend_connection = $broker_connection;
 

--- a/src/CeleryAbstract.php
+++ b/src/CeleryAbstract.php
@@ -18,7 +18,11 @@ abstract class CeleryAbstract
     private $backend_connection_details = [];
     private $backend_amqp = null;
 
+    /** @var bool Is broker connected? **/
     private $isConnected = false;
+
+    /** @var Config **/
+    protected $config = null;
 
     private function SetDefaultValues($details)
     {
@@ -151,7 +155,13 @@ abstract class CeleryAbstract
         }
 
         if ($async_result) {
-            return new AsyncResult($id, $this->backend_connection_details, $task_array['task'], $args);
+            return new AsyncResult(
+                $id,
+                $this->backend_connection_details,
+                $task_array['task'],
+                $args,
+                !$this->config->keep_messages_in_queue
+            );
         } else {
             return true;
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -19,6 +19,8 @@ class Config
 	 * can be modified.
 	 */
 	protected $config = [
+		// Whether to delete messages from queue
+		// after they were _successfully_ returned.
 		'keep_messages_in_queue' => false,
 	];
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,7 @@ class Config
 
 	public function __construct(array $config = [])
 	{
-		$this->config = $config;
+		$this->config = array_merge($this->config, $config);
 	}
 
 	public function __get($name)

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Celery;
+
+/**
+ * A container for arbitrary configuration for instances of
+ * the Celery class. Meant to reduce the 'parameter bloat'
+ * of the Celery::__construct() method.
+ */
+class Config
+{
+
+	/**
+	 * @var array
+	 *
+	 * Configuration values. All possible configuration keys
+	 * should be listed here and have a default value defined,
+	 * so it is apparent what parameters for the Celery instance
+	 * can be modified.
+	 */
+	protected $config = [
+		'keep_messages_in_queue' => false,
+	];
+
+	public function __construct(array $config = [])
+	{
+		$this->config = $config;
+	}
+
+	public function __get($name)
+	{
+		if (!array_key_exists($name, $this->config)) {
+			throw new \LogicException("Config parameter '$name' not set");
+		}
+
+		return $this->config[$name];
+	}
+
+	public function __set($name, $value)
+	{
+		throw new \LogicException("Cannot modify already created " . __CLASS__ . " object");
+	}
+
+}

--- a/tests/CeleryAMQPLibTest.php
+++ b/tests/CeleryAMQPLibTest.php
@@ -38,7 +38,7 @@ namespace Celery\Tests;
 
 class CeleryAMQPLibTest extends CeleryTest
 {
-    public function get_c()
+    public function get_c(\Celery\Config $config = null)
     {
         return new \Celery\Celery(
             'localhost', /* Server */
@@ -48,7 +48,11 @@ class CeleryAMQPLibTest extends CeleryTest
             'celery', /* exchange */
             'celery', /* binding */
             5672, /* port */
-            'php-amqplib' /* connector */
+            'php-amqplib' /* connector */,
+            false, /* persistent messages */
+            0, /* result expire */
+            [], /* ssl options */
+            $config /* config object */
         );
     }
 }

--- a/tests/CeleryPECLTest.php
+++ b/tests/CeleryPECLTest.php
@@ -38,7 +38,7 @@ namespace Celery\Tests;
 
 class CeleryPECLTest extends CeleryTest
 {
-    public function get_c()
+    public function get_c(\Celery\Config $config = null)
     {
         return new \Celery\Celery(
             'localhost', /* Server */
@@ -48,7 +48,11 @@ class CeleryPECLTest extends CeleryTest
             'celery', /* exchange */
             'celery', /* binding */
             5672, /* port */
-            'pecl' /* connector */
+            'pecl' /* connector */,
+            false, /* persistent messages */
+            0, /* result expire */
+            [], /* ssl options */
+            $config /* config object */
         );
     }
 }

--- a/tests/CeleryRedisTest.php
+++ b/tests/CeleryRedisTest.php
@@ -38,7 +38,7 @@ namespace Celery\Tests;
 
 class CeleryRedisTest extends CeleryTest
 {
-    public function get_c()
+    public function get_c(\Celery\Config $config = null)
     {
         return new \Celery\Celery(
             'localhost', /* Server */
@@ -48,7 +48,11 @@ class CeleryRedisTest extends CeleryTest
             'celery', /* exchange */
             'celery', /* binding */
             6379, /* port */
-            'redis' /* connector */
+            'redis' /* connector */,
+            false, /* persistent messages */
+            0, /* result expire */
+            [], /* ssl options */
+            $config /* config object */
         );
     }
 }

--- a/testscenario/tasks.py
+++ b/testscenario/tasks.py
@@ -33,3 +33,26 @@ def delayed():
 @task
 def get_fibonacci():
     return [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
+
+
+@task(bind=True)
+def long_running_with_progress(self):
+    print("Start long running with progress.")
+    self.update_state(state="PROGRESS", meta={"progress": 5})
+    print("5")
+    time.sleep(0.1)
+    self.update_state(state="PROGRESS", meta={"progress": 20})
+    print("20")
+    # Intentionally too much - to simulate a long delay between two
+    # meta data updates.
+    time.sleep(20)
+    self.update_state(state="PROGRESS", meta={"progress": 40})
+    print("40")
+    time.sleep(1)
+    self.update_state(state="PROGRESS", meta={"progress": 60})
+    print("60")
+    time.sleep(1)
+    self.update_state(state="PROGRESS", meta={"progress": 80})
+    print("80")
+    time.sleep(1)
+    print("Done.")


### PR DESCRIPTION
This can be done via optional `Config` object's `keep_messages_in_queue` option.

This differs from `\Celery\CeleryAbstract::getAsyncResultMessage()` method *(which also doesn't remove the message from the queue)* in the fact that client gets back the `AsyncResult` instance itself - and not only the message body. 

*Note: Adapted to current codebase from this older closed PR: https://github.com/gjedeer/celery-php/pull/66*

## A bit more explained rationale

If AsyncResult is serialized *(eg. stored to client's cache)*, the `"complete_result"` property is **serialized along with it**. That might cause somewhat unexpected behaviour, when trying to fetch *(eg. meta)* data, which can change during the task's execution *(eg. progress percentage, etc.)*. Serialized `AsyncResult` with non-empty `"complete_result"` ***will never try to update*** its already established `"complete_result"`.

The client might try to "hack" this somewhat non-practical behaviour with serializing the `AsyncResult` object only once - right after the task is submitted; when the `"complete_result"` is still empty. `AsyncResult` will then be always *(eg. in each request)* unserialized with empty `"complete_result"` and thus any query for task's data/result body ***will always fetch the latest state***.

Sadly, because the **default behaviour of *Celery-PHP* is to remove any messages** fetched from the queue, this can not normally be done *(since, as was mentioned, fetching the result of the same task will - by default - delete the message)*.

***It can now be done via 'keep_messages_in_queue' being TRUE.***