### PR TITLE
Fix CI by pinning the version of amqp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,29 @@ sudo: required
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+  - '5.4'
+  - '5.5'
+  - '5.6'
+
+services:
+  - rabbitmq
+  - redis-server
 
 before_install:
   - composer --no-interaction validate --strict
   # Install PECL amqp package
-  - yes '' | pecl install amqp
+  - sudo apt-get install librabbitmq-dev
+  - yes '' | pecl install amqp-1.4.0
   # RabbitMQ
-  - sudo /etc/init.d/rabbitmq-server start
   - sudo rabbitmqctl add_user gdr test
   - sudo rabbitmqctl add_vhost celeryamqplib
   - sudo rabbitmqctl set_permissions -p celeryamqplib gdr '.*' '.*' '.*'
   - sudo rabbitmqctl add_vhost celerypecl
   - sudo rabbitmqctl set_permissions -p celerypecl gdr '.*' '.*' '.*'
-  # Redis
-  - sudo start redis-server
   # Celery
   - sudo apt-get install -y python-virtualenv
   - virtualenv venv
-  - venv/bin/pip install 'celery<4' redis
+  - venv/bin/pip install celery redis
   - venv/bin/celery worker --config celeryamqplibconfig --workdir $PWD/testscenario --detach --pidfile celeryamqplib.pid
   - venv/bin/celery worker --config celerypeclconfig --workdir $PWD/testscenario --detach --pidfile celerypecl.pid
   - venv/bin/celery worker --config celeryredisconfig --workdir $PWD/testscenario --detach --pidfile celeryredis.pid

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Last PHP-amqplib version tested is 2.5.1.
 
 Last predis version tested is 1.0.1.
 
-Last Celery version tested is 3.1.19 (but check out the [celery4 branch](https://github.com/gjedeer/celery-php/tree/celery4))
+Tested on Celery 4.0+.
 
 [API documentation](https://massivescale.net/celery-php/li_celery-php.html) is dead, [help wanted](https://github.com/gjedeer/celery-php/issues/82)
 

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,13 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
+        "ext-amqp": "*",
         "php-amqplib/php-amqplib": "*",
         "phpunit/phpunit": "<6.0.0",
         "predis/predis": "*"
     },
     "suggest": {
+        "ext-amqp": "Adds support for the AMQP extension for PHP backend",
         "php-amqplib/php-amqplib": "Adds support for the php-amqplib, AMQP library for PHP, backend",
         "predis/predis": "Adds support for the predis, PHP client library for Redis, backend"
     },


### PR DESCRIPTION
Must install the Ubuntu package librabbitmq-dev for the amqp extension
to successfully compile.

Can't install the latest version of the amqp extension as it does not
support the installed version of librabbitmq.

Can't test against PHP 7.0+ as the older version of the amqp extension
can't successfully compile.

Use RabbitMQ 4+ to be compatible with the configurations in
testscenario.

Move rabbitmq and redis service invocations to Travis's "services"
feature.