### PR TITLE
Use Celery task protocol version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
   results exchange.
 - The `Celery` constructor no longer accepts the argument
   `persistent_messages`. It was previously unused.
+- celery-php now uses Celery task protocol version 2 and requires Celery 4.0+.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Last PHP-amqplib version tested is 2.5.1.
 
 Last predis version tested is 1.0.1.
 
-Tested on Celery 4.0+.
+Requires Celery 4.0+.
 
 [API documentation](https://massivescale.net/celery-php/li_celery-php.html) is dead, [help wanted](https://github.com/gjedeer/celery-php/issues/82)
 

--- a/src/AMQPLibConnector.php
+++ b/src/AMQPLibConnector.php
@@ -81,7 +81,7 @@ class AMQPLibConnector extends AbstractAMQPConnector
     {
     }
 
-    public function PostToExchange($connection, $details, $task, $params)
+    public function PostToExchange($connection, $details, $body, $properties, $headers)
     {
         $ch = $connection->channel();
 
@@ -106,10 +106,8 @@ class AMQPLibConnector extends AbstractAMQPConnector
             $details['exchange']    /* exchange name - "celery" */
         );
 
-        $msg = new \PhpAmqpLib\Message\AMQPMessage(
-            $task,
-            $params
-        );
+        $properties['application_headers'] = new \PhpAmqpLib\Wire\AMQPTable($headers);
+        $msg = new \PhpAmqpLib\Message\AMQPMessage($body, $properties);
 
         $ch->basic_publish($msg, $details['exchange'], $details['routing_key']);
 

--- a/src/AbstractAMQPConnector.php
+++ b/src/AbstractAMQPConnector.php
@@ -77,11 +77,12 @@ abstract class AbstractAMQPConnector
      * Post a task to exchange specified in $details
      * @param AMQPConnection $connection Connection object
      * @param array $details Array of connection details
-     * @param string $task JSON-encoded task
-     * @param array $params AMQP message parameters
+     * @param string $body JSON-encoded task body
+     * @param array $properties AMQP message properties
+     * @param array $headers Celery task headers
      * @return bool true if posted successfuly
      */
-    abstract public function PostToExchange($connection, $details, $task, $params);
+    abstract public function PostToExchange($connection, $details, $body, $properties, $headers);
 
     /**
      * Return result of task execution for $task_id

--- a/src/PECLAMQPConnector.php
+++ b/src/PECLAMQPConnector.php
@@ -40,18 +40,20 @@ class PECLAMQPConnector extends AbstractAMQPConnector
      * Post a task to exchange specified in $details
      * @param AMQPConnection $connection Connection object
      * @param array $details Array of connection details
-     * @param string $task JSON-encoded task
-     * @param array $params AMQP message parameters
+     * @param string $body JSON-encoded task body
+     * @param array $properties AMQP message properties
+     * @param array $headers Celery task headers
+     * @return bool true if posted successfuly
      */
-    public function PostToExchange($connection, $details, $task, $params)
+    public function PostToExchange($connection, $details, $body, $properties, $headers)
     {
         $ch = $connection->channel;
         $xchg = new \AMQPExchange($ch);
         $xchg->setName($details['exchange']);
 
-        $success = $xchg->publish($task, $details['binding'], 0, $params);
+        $properties['headers'] = $headers;
 
-        return $success;
+        return $xchg->publish($body, $details['binding'], 0, $properties);
     }
 
     /**


### PR DESCRIPTION
By using the newer protocol, helps ensure that celery-php remains forward compatible.

For details on the protocol, see the Celery docs:

http://docs.celeryproject.org/en/latest/internals/protocol.html

The protocol was first introduce with Celery 4.0.

http://docs.celeryproject.org/en/latest/history/whatsnew-4.0.html#new-task-message-protocol